### PR TITLE
Dockerfile to set up the environment needed to run a GWC release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN cd /root/gwc-release && bundle install
 COPY setup_git.sh /usr/local/bin/setup_git.sh
 
 # Make the script executable
-RUN chmod +x /usr/local/bin/setup_git.sh
+RUN dos2unix /usr/local/bin/setup_git.sh && \
+	chmod +x /usr/local/bin/setup_git.sh
 
 # Set the script as the entrypoint
 ENTRYPOINT ["/usr/local/bin/setup_git.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# Use an official Ruby 2.x image as a base
+FROM ruby:2.7
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV EDITOR=vim
+
+# Install dependencies and tools
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    wget \
+    unzip \
+    openjdk-11-jdk \
+    python3-pip \
+    dos2unix \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Maven 3.9.9
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip -O /tmp/maven.zip && \
+    unzip /tmp/maven.zip -d /opt && \
+    ln -s /opt/apache-maven-3.9.9 /opt/maven && \
+    ln -s /opt/maven/bin/mvn /usr/bin/mvn && \
+    rm /tmp/maven.zip
+
+# Set Maven environment variables
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=$MAVEN_HOME/bin:$PATH
+
+# Prepare settings.xml file
+COPY settings.xml /root/.m2/settings.xml
+
+# Install the latest Sphinx
+RUN pip3 install --upgrade pip && \
+    pip3 install --upgrade sphinx
+
+# Install XSDDoc (assuming the latest version is 0.11) and fix line endings
+RUN wget https://sourceforge.net/projects/xframe/files/xsddoc/xsddoc-1.0/xsddoc-1.0.zip/download -O /tmp/xsddoc.zip && \
+    unzip /tmp/xsddoc.zip -d /opt && \
+    dos2unix /opt/xsddoc-1.0/bin/xsddoc && \
+    chmod +x /opt/xsddoc-1.0/bin/xsddoc && \
+    rm /tmp/xsddoc.zip
+
+# Patch XSDDoc to run on Java 11
+RUN curl "https://repo1.maven.org/maven2/xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar" -o /opt/xsddoc-1.0/lib/xercesImpl.jar
+
+# Set Java environment variables
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV PATH=$JAVA_HOME/bin:/opt/xsddoc-1.0/bin:$PATH
+
+# Clone the GeoWebCache repositories
+RUN git clone https://github.com/GeoWebCache/gwc-release.git /root/gwc-release
+RUN git clone https://github.com/GeoWebCache/geowebcache.git /root/geowebcache
+RUN cp /root/gwc-release/release.rb /root/geowebcache
+
+# Make sure the release.rb dependencies are installed
+RUN gem install bundler -v 2.4.22
+RUN cd /root/gwc-release && bundle install
+
+# Copy the git setup script into the container
+COPY setup_git.sh /usr/local/bin/setup_git.sh
+
+# Make the script executable
+RUN chmod +x /usr/local/bin/setup_git.sh
+
+# Set the script as the entrypoint
+ENTRYPOINT ["/usr/local/bin/setup_git.sh"]
+
+# Get in the home directory when the shell is executed
+WORKDIR /root
+
+# By default, run a bash shell
+CMD ["/bin/bash"]
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,36 @@
+# GWC release docker image
+
+The ruby script used below for the automated release of GeoWebCache, relied on an old setup that was difficult to reproduce.  This resulted in a small number of volunteers being able to release GWC, until Andrea created this docker image to ease the pain.
+
+## Instructions for use
+
+Check out the `docker` branch from https://github.com/aaime/gwc-release/tree/docker and enter this directory.
+
+Build the image from the Dockerfile with:
+
+`docker build -t gwc_release:0.1 .`
+
+Run the image, passing in Git credentials as environment variables:
+
+`docker run -it -v d:/tmp/m2:/root/.m2 -e GIT_USERNAME="user" -e GIT_EMAIL="someone@somewhere.insummertime" gwc_release:0.1`
+
+Note that the maven repository /root/.m2 is mapped to the host's d:/tmp/m2 for persistence.
+
+Once started, one has to hand-edit the /root/.m2/settings.xml file to add the repo.osgeo.org credentials (OSGeo login, needs nexus permissions suitable for release: geoserver - geowebcache uses geoserver repo) (maybe we could make this also as part of the docker run command above?).
+
+Finally, in order to tag at the end, one needs to create a GitHub personal access token that will be used as the password for that step (go to your user settings, developer settings (right at the bottom, left), and create a personal access token). This could also be avoided by replacing with a step to copy over the identification certificate, and then checkout GWC using the ssh URL.
+
+### Now that docker is set up, you're ready to continue with the original GWC release instructions below (skipping Installation):
+
 This ruby script allows to automate the release of GeoWebCache.
+
+Requirements
+------------
+
+* Commit access to the https://github.com/GeoWebCache repo (team-geowebcache)
+* GitHub personal access token
+* repo.osgeo.org credentials (OSGeo login) with nexus permissions suitable for release: geoserver
+* SourceForge credentials
 
 Installation
 ------------
@@ -37,10 +69,12 @@ export EDITOR=vi
 Also make sure xsddoc in in the path.
 
 
-Releasing a stable release
---------------------------
+Releasing a stable/maintenance release
+--------------------------------------
 
-Assuming one wants to release a GWC 1.9.3, which depends on GeoToools 15.4, then run the following commands:
+First, manually check the GitHub commit history e.g. https://github.com/GeoWebCache/geowebcache/commits/1.26.x/ for the Improvements or Fixes to go into the Release notes.
+
+Assuming one wants to release a GWC 1.9.3, which depends on GeoTools 15.4, then run the following commands:
 
 ````
 ruby release.rb --branch 1.9.x --long-version 1.9.3 --short-version 1.9 --gt-version 15.4 --type stable reset update 
@@ -61,7 +95,9 @@ ruby release.rb --branch 1.9.x --long-version 1.9.3 --short-version 1.9 --gt-ver
 Creating a new branch
 ---------------------
 
-Same as above, but with these instructions:
+This is applicable when preparing the Release Candidate or .0 Initial release
+
+Instead of the 4 ruby commands above, use these commands:
 
 ````
 ruby release.rb --branch main reset

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>nexus</id>
+      <username>yourNameHere</username>
+      <password>yourPasswordHere</password>
+    </server>
+  </servers>
+</settings>

--- a/setup_git.sh
+++ b/setup_git.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Exit on error
+set -e
+
+# Configure Git username and email if provided
+if [ -n "$GIT_USERNAME" ]; then
+    git config --global user.name "$GIT_USERNAME"
+fi
+
+if [ -n "$GIT_EMAIL" ]; then
+    git config --global user.email "$GIT_EMAIL"
+fi
+
+exec /bin/bash


### PR DESCRIPTION
Here is a first tentative to make the GWC release process repeatable by others.
The Dockefile takes care of various "magic" bits that are needed to run the release scripts and the tools nowadays.

The image can be built using:

``docker build -t gwc_release:0.1 .``

and then run passing the git identifications as env vars:

``docker run -it -e GIT_USERNAME="user" -e GIT_EMAIL="someone@somewhere.insummertime" gwc_release:0.1``

Once started, one has to hand-edit the ``/root/.m2/settings.xml`` file to add the repo.osgeo.org (maybe we could make this also as part of the docker run command above?).

Finally, in order to tag at the end, one needs to create a github personal access token that will be used as the password for that step (go to your user settings, developer settings, and create a persona access token). This could also be avoided by replacing with a step to copy over the identification certificate, and then checkout GWC using the ssh URL.

As a final note, running it as above, the container will cease to exist once one exists, which is annoying as one as to redo various things by hand, and the maven repository has to be filled again. Would be probably nicer if the docker container could just stay there, be stopped and restarted on a as-needed basis.

@jodygarnett @smithkm @petersmythe can you review and possibly help to make this better?